### PR TITLE
KS-121 Added a simple check for blank PTOK value.

### DIFF
--- a/src/Kount/Util/Khash.php
+++ b/src/Kount/Util/Khash.php
@@ -52,7 +52,7 @@ class Kount_Util_Khash {
   public static function hashPaymentToken ($token) {
     $firstSix = mb_substr($token, 0, 6, 'latin1');
     $hash = self::hash($token, 14);
-    return (null == $token) ? '' :  "{$firstSix}{$hash}";
+    return (null == $token) ? '' : "{$firstSix}{$hash}";
   }
 
   /**

--- a/src/Kount/Util/Khash.php
+++ b/src/Kount/Util/Khash.php
@@ -52,7 +52,7 @@ class Kount_Util_Khash {
   public static function hashPaymentToken ($token) {
     $firstSix = mb_substr($token, 0, 6, 'latin1');
     $hash = self::hash($token, 14);
-    return "{$firstSix}{$hash}";
+    return (null == $token) ? '' :  "{$firstSix}{$hash}";
   }
 
   /**

--- a/tests/Kount/Ris/integration/KhashFunctionalityTest.php
+++ b/tests/Kount/Ris/integration/KhashFunctionalityTest.php
@@ -43,4 +43,10 @@ class ConfigurationSaltTest extends PHPUnit_Framework_TestCase
 
     $this->assertEquals('666666FEXQI1QS6TH2O5', $token);
   }
+
+  public function testHashWithNull() {
+    $token = Kount_Util_Khash::hashPaymentToken(null);
+
+    $this->assertEquals(null, $token);
+  }
 }


### PR DESCRIPTION
Added a simple check for a blank PTOK value in hashPaymentToken method, after a brief discussion with boyan on how this is implemented in the java sdk and noticed that such functionality is missing from the php sdk.  @gallilama this simple fix sorts out [KS-121](https://kopana.atlassian.net/browse/KS-121) as far as I can tell from my testing with a direct RIS call.