### PR TITLE
KS-140 Replaced stopwatch logic and added methods to view response as…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,25 @@
 Kount RIS PHP SDK CHANGELOG
 ===========================
 
+Version 6.5.2
+=====================
+06/27/2017
+1. Added getResponseAsDict() method for retrieving the response fields as array.
+2. Removed the stopwatch package and introduced php's native microtime() to track milliseconds.
+3. Added autoload configuration in composer.json, so that when the user opts for a composer installation he would have to only include the autoload in vendor folder.
+
+Version 6.5.1
+=====================
+06/23/2017
+1. Improved communication logging
+2. Added more information to connection headers
+3. Integrated more payment types, see https://api.test.kount.net/rpc/support/payments.html
+
+Version 6.5.0
+=====================
+05/29/2017
+1. SALT phrase configurable as a settings variable
+
 Version 6.4.2
 =====================
 04/07/2017

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
   "require-dev": {
     "phpunit/phpunit": "4.8",
     "phpdocumentor/phpdocumentor": "2.*"
+  },
+  "autoload": {
+    "classmap": [
+      "./src/"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "4.8",
-    "phpdocumentor/phpdocumentor": "2.*",
-    "symfony/stopwatch": "*"
+    "phpdocumentor/phpdocumentor": "2.*"
   }
 }

--- a/src/Kount/Ris/Request.php
+++ b/src/Kount/Ris/Request.php
@@ -9,8 +9,6 @@
 define('RSA_PUBLIC_KEY', realpath(dirname(__FILE__) .
     DIRECTORY_SEPARATOR . 'etc' . DIRECTORY_SEPARATOR . 'rsa.public.key'));
 
-require __DIR__ . "/../../../vendor/autoload.php";
-
 /**
  * Common abstract class for Kount_Ris_Request_Inquiry and Kount_Ris_Request_Update objects.
  * CURL support must be enabled.
@@ -279,8 +277,7 @@ abstract class Kount_Ris_Request {
           "]");
     }
 
-    $stopWatch = new \Symfony\Component\Stopwatch\Stopwatch();
-    $start = $stopWatch->start('ris');
+    $startTimer = microtime(true);
 
     // validate first
     $errors = Kount_Ris_Validate::validate($this->data);
@@ -354,11 +351,11 @@ abstract class Kount_Ris_Request {
     }
     curl_close($ch);
 
-    $event = $stopWatch->stop('ris');
-    $timeElapsed = $event->getDuration() . "ms";
+    $time = microtime(true) - $startTimer;
+    $timeInMs = round($time * 1000) . "ms";
 
     if($this->logger->getRisLogger()) {
-      $risLogMessage = "merc=" . $this->data['MERC'] . " " . "sess=" . $this->data['SESS'] . " " . "sdk_elapsed=" . $timeElapsed;
+      $risLogMessage = "merc=" . $this->data['MERC'] . " " . "sess=" . $this->data['SESS'] . " " . "sdk_elapsed=" . $timeInMs;
       $this->logger->debug("{$risLogMessage}");
     }
 

--- a/src/Kount/Ris/Response.php
+++ b/src/Kount/Ris/Response.php
@@ -591,6 +591,24 @@ class Kount_Ris_Response {
   }
 
   /**
+   * Safely get all of the values from the RIS response.
+   *
+   * @return array Response fields
+   */
+  protected function safeGetResponseAsDict () {
+    return !is_null($this->response) ? $this->response : '';
+  }
+
+  /**
+   * Get an array with the fields from the RIS response
+   *
+   * @return array Response fields
+   */
+  public function getResponseAsDict () {
+    return $this->safeGetResponseAsDict();
+  }
+
+  /**
    * Get an array of the rules triggered by this Response.
    * @return array Rules triggered
    */

--- a/src/Kount/Ris/Response.php
+++ b/src/Kount/Ris/Response.php
@@ -591,21 +591,14 @@ class Kount_Ris_Response {
   }
 
   /**
-   * Safely get all of the values from the RIS response.
-   *
-   * @return array Response fields
-   */
-  protected function safeGetResponseAsDict () {
-    return !is_null($this->response) ? $this->response : '';
-  }
-
-  /**
-   * Get an array with the fields from the RIS response
+   * Get an array with the fields from the RIS response.
+   * Getting the response array is null-safe.
    *
    * @return array Response fields
    */
   public function getResponseAsDict () {
-    return $this->safeGetResponseAsDict();
+
+    return !is_null($this->response) ? $this->response : '';
   }
 
   /**


### PR DESCRIPTION
… array.

Removed the stopwatch symfony package because it was not necessary and it added additional steps in setting up the sdk, instead used php's native microtime(), the result is the same. Also added the method getResponseAsDict in Response.php so that we can have the response fields presented as an array which we can map and manipulate.