### PR TITLE
KS-165 Replaced exception thrown, where the salt is actually being used.

### DIFF
--- a/src/Kount/Ris/ArraySettings.php
+++ b/src/Kount/Ris/ArraySettings.php
@@ -112,17 +112,10 @@ class Kount_Ris_ArraySettings implements Kount_Ris_Settings {
   /**
    * The Salt phrase for hashing credit card numbers.
    *
-   * @throws Exception when the SALT_PHRASE setting in settings.ini
-   * does not exist or is set to null or empty value.
    * @return string SALT PHRASE
    */
 
   public function getSaltPhrase() {
-    if(!$this->settings['SALT_PHRASE']) {
-      throw new Exception(
-        "Unable to get configuration setting 'SALT_PHRASE'. " .
-        "Check that the SALT_PHRASE setting exists and is not set to null or empty string. ");
-    }
     return $this->settings['SALT_PHRASE'];
   }
 

--- a/src/Kount/Util/Khash.php
+++ b/src/Kount/Util/Khash.php
@@ -118,10 +118,15 @@ class Kount_Util_Khash {
    *
    * @param string $data Data to hash
    * @param int $len Length of hash to retain
+   * @throws Exception if $salt is not configured.
    * @return string Hashed data
    */
   public static function hash ($data, $len) {
     $salt = self::getSaltPhrase();
+    if($salt == null || !isset($salt)) {
+      throw new Exception("Unable to get configuration setting 'SALT_PHRASE'. " .
+        "Check that the SALT_PHRASE setting exists and is not set to null or empty string. ");
+    }
     static $a = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
     $r = sha1("{$data}.{$salt}");

--- a/src/Kount/Util/Khash.php
+++ b/src/Kount/Util/Khash.php
@@ -118,7 +118,7 @@ class Kount_Util_Khash {
    *
    * @param string $data Data to hash
    * @param int $len Length of hash to retain
-   * @throws Exception if $salt is not configured.
+   * @throws Exception if $salt is not configured in src/settings.ini or custom settings file.
    * @return string Hashed data
    */
   public static function hash ($data, $len) {


### PR DESCRIPTION
- Replaced the exception for missing salt to where it's actually used.