### PR TITLE
Default values for optional params, default connection timeout

### DIFF
--- a/src/Kount/Ris/ArraySettings.php
+++ b/src/Kount/Ris/ArraySettings.php
@@ -73,7 +73,7 @@ class Kount_Ris_ArraySettings implements Kount_Ris_Settings {
    * @return string Filesystem path to PEM encoded x509 certificate
    */
   public function getX509CertPath () {
-    return $this->settings['PEM_CERTIFICATE'];
+    return $this->settings['PEM_CERTIFICATE'] ?? null;
   }
 
   /**
@@ -81,7 +81,7 @@ class Kount_Ris_ArraySettings implements Kount_Ris_Settings {
    * @return string Filesystem path to PEM encoded x509 private key
    */
   public function getX509KeyPath () {
-    return $this->settings['PEM_KEY_FILE'];
+    return $this->settings['PEM_KEY_FILE'] ?? null;
   }
 
   /**
@@ -89,7 +89,7 @@ class Kount_Ris_ArraySettings implements Kount_Ris_Settings {
    * @return string Passphrase needed to decrypt PEM encoded x509 private key
    */
   public function getX509Passphrase () {
-    return $this->settings['PEM_PASS_PHRASE'];
+    return $this->settings['PEM_PASS_PHRASE'] ?? null;
   }
 
   /**
@@ -97,7 +97,7 @@ class Kount_Ris_ArraySettings implements Kount_Ris_Settings {
    * @return int Number of seconds to timeout
    */
   public function getConnectionTimeout () {
-    return $this->settings['CONNECT_TIMEOUT'];
+    return $this->settings['CONNECT_TIMEOUT'] ?? Kount_Ris_Request::CONNECTION_TIMEOUT;
   }
 
   /**
@@ -106,7 +106,7 @@ class Kount_Ris_ArraySettings implements Kount_Ris_Settings {
    * @return string API key
    */
   public function getApiKey () {
-    return $this->settings['API_KEY'];
+    return $this->settings['API_KEY'] ?? null;
   }
 
   /**

--- a/src/Kount/Ris/Request.php
+++ b/src/Kount/Ris/Request.php
@@ -198,6 +198,12 @@ abstract class Kount_Ris_Request
    * @var string
    */
   const TOKEN_TYPE = "TOKEN";
+  
+  /**
+   * Connection timeout value.
+   * @var int
+   */
+  const CONNECTION_TIMEOUT = 30;
 
   /**
    * A logger binding.
@@ -248,11 +254,15 @@ abstract class Kount_Ris_Request
     $this->setMerchantId($this->settings->getMerchantId());
     $this->setVersion(self::VERSION);
     $this->setUrl($this->settings->getRisUrl());
-    $this->setApiKey($this->settings->getApiKey());
-    $this->setCertificate(
-      $this->settings->getX509CertPath(),
-      $this->settings->getX509KeyPath(),
-      $this->settings->getX509Passphrase());
+    if ($this->settings->getApiKey()) {
+      $this->setApiKey($this->settings->getApiKey());
+    } else {
+      $this->setCertificate(
+        $this->settings->getX509CertPath(),
+        $this->settings->getX509KeyPath(),
+        $this->settings->getX509Passphrase()
+      );
+    }
     $this->setConnectionTimeout($this->settings->getConnectionTimeout());
 
     // KHASH payment encoding is enabled by default.


### PR DESCRIPTION
If you're using an API Key the Certificate parameters should be optional, and conversely if you're using a Certificate the API Key parameter should be optional. However, no matter which method you're using if you don't set all parameters you will encounter `undefined index` errors. Workaround is to specify defaults for the Certificate and API Key parameters.

I have also specified a default value for the connection timeout. The recommended value is 30 as described in the `settings.ini`.