### PR TITLE
Updated Default SDK VERSION 0695 to 0700 For PHP

### DIFF
--- a/src/Kount/Ris/Request.php
+++ b/src/Kount/Ris/Request.php
@@ -28,7 +28,7 @@ abstract class Kount_Ris_Request
    * RIS API Version
    * @var string
    */
-  const VERSION = '0695';
+  const VERSION = '0700';
 
   /**
    * RIS data collection for the post

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -8,7 +8,7 @@ MERCHANT_ID=
 
 ; Kount RIS release version
 ; Set your version release number here appropriately, for now it has to match the release number in the branch you want to merge to master.
-VERSION_NUMBER=0695
+VERSION_NUMBER=0700
 
 ; SDK release version
 ; Set the sdk release version which will be used for git tagging in github

--- a/tests/Kount/Ris/UtilityHelperTest.php
+++ b/tests/Kount/Ris/UtilityHelperTest.php
@@ -7,7 +7,7 @@ class UtilityHelperTest {
   const PTOK = '0007380568572514';
   //last four numbers of credit card
   const LAST4 = '2514';
-  const VERS = '0695';
+  const VERS = '0700';
   const EMAIL = 'sdkTest@kountsdktestdomain.com';
   const SITE = 'DEFAULT';
   const CURR = 'USD';

--- a/tests/Kount/Ris/integration/RisSuiteTest.php
+++ b/tests/Kount/Ris/integration/RisSuiteTest.php
@@ -203,7 +203,7 @@ class RisSuiteTest extends PHPUnit_Framework_TestCase
     $update = new Kount_Ris_Request_Update();
     $update->setMode('U');
     $update->setSessionId($session);
-    $update->setVersion('0695');
+    $update->setVersion('0700');
     $update->setTransactionId($transaction);
     $update->setOrderNumber($order);
     $update->setParm('PTOK', Kount_Util_Khash::hashPaymentToken('5386460135176807'));
@@ -240,7 +240,7 @@ class RisSuiteTest extends PHPUnit_Framework_TestCase
     $update = new Kount_Ris_Request_Update();
     $update->setMode('X');
     $update->setSessionId($session);
-    $update->setVersion('0695');
+    $update->setVersion('0700');
     $update->setTransactionId($transaction);
     $update->setOrderNumber($order);
     $update->setMerchantId(self::MERCHANT_ID);


### PR DESCRIPTION
Updated default SDK version '0695' to '0700' for PHP SDK (all code).