### PR TITLE
Removed invalid curl configuration option

### DIFF
--- a/src/Kount/Ris/Request.php
+++ b/src/Kount/Ris/Request.php
@@ -301,7 +301,6 @@ abstract class Kount_Ris_Request
     curl_setopt($ch, CURLOPT_URL, $this->url);
     curl_setopt($ch, CURLOPT_HEADER, 0);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLINFO_SSL_VERIFYRESULT, 0);
     curl_setopt($ch, CURLOPT_TIMEOUT, $this->connectionTimeout);
     curl_setopt($ch, CURLOPT_POST, 1);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);


### PR DESCRIPTION
PHP 8 now throws errors for invalid curl configuration options. This was never a valid option, but was not failing in older versions of PHP.